### PR TITLE
bugfix: Add '/' in front of bin/bash in initdb.sh

### DIFF
--- a/db/sql/initdb.sh
+++ b/db/sql/initdb.sh
@@ -1,4 +1,4 @@
-#!bin/bash
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
fix #32 
before- `!bin/bash`
after- `!/bin/bash`

